### PR TITLE
Issue #18: Bump up 1.0.0 release version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <packaging>jar</packaging>
     <groupId>org.webjars</groupId>
     <artifactId>materializecss</artifactId>
-    <version>1.0.0-rc.3-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <name>Materialize</name>
     <description>WebJar for Materialize</description>
     <url>http://webjars.org</url>


### PR DESCRIPTION
Hello,

I have created PR according to https://github.com/webjars/materializecss/issues/18

during `release:perform` goal, variable `${upstream.url}` in maven pom.xml should point to latest materialize release distribution: https://github.com/Dogfalo/materialize/releases/download/1.0.0/materialize-v1.0.0.zip

---
Regards,
Maksim

